### PR TITLE
Implement job scheduling

### DIFF
--- a/rift/api/resources.py
+++ b/rift/api/resources.py
@@ -21,6 +21,7 @@ from rift.api.common.resources import ApiResource
 from rift.api.schemas import get_validator
 from rift.api.schemas.job import job_schema
 from rift.api.schemas.target import target_schema
+from rift.api.schemas.schedule import schedule_schema
 from rift.data.models.job import Job
 from rift.data.models.tenant import Tenant
 from rift.data.models.target import Target
@@ -155,6 +156,8 @@ class TargetResource(ApiResource):
 
 class SchedulesResource(ApiResource):
 
+    validator = get_validator(schedule_schema)
+
     def on_get(self, req, resp, tenant_id):
         schedules_list = [
             s.as_dict() for s in Schedule.get_schedules(tenant_id)
@@ -163,8 +166,7 @@ class SchedulesResource(ApiResource):
 
     def on_post(self, req, resp, tenant_id):
         schedule_id = str(uuid.uuid4())
-        # TODO: do validation
-        body = self.load_body(req)
+        body = self.load_body(req, self.validator)
         body['id'] = schedule_id
 
         schedule = Schedule.build_schedule_from_dict(tenant_id, body)

--- a/rift/api/resources.py
+++ b/rift/api/resources.py
@@ -188,9 +188,8 @@ class ScheduleResource(ApiResource):
         schedule = Schedule.get_schedule(tenant_id, schedule_id)
         if schedule:
             for entry in schedule.entries:
-                delay_seconds = entry.delay.get_total_seconds()
                 execute_job.apply_async((entry.job_id,),
-                                        countdown=delay_seconds)
+                                        countdown=entry.delay)
             resp.status = falcon.HTTP_200
         else:
             self._not_found(resp, schedule_id)

--- a/rift/api/resources.py
+++ b/rift/api/resources.py
@@ -191,7 +191,7 @@ class ScheduleResource(ApiResource):
         if schedule:
             for entry in schedule.entries:
                 execute_job.apply_async((entry.job_id,),
-                                        countdown=entry.delay)
+                                        countdown=entry.get_total_seconds())
             resp.status = falcon.HTTP_200
         else:
             self._not_found(resp, schedule_id)

--- a/rift/api/schemas/schedule.py
+++ b/rift/api/schemas/schedule.py
@@ -1,0 +1,23 @@
+_entry_schema = {
+    "additionalProperties": False,
+    "properties": {
+        "job_id": {"type": "string"},
+        "delay": {
+            "type": "integer",
+            "minimum": 0
+        },
+    },
+    "required": ["job_id", "delay"],
+}
+
+schedule_schema = {
+    "additionalProperties": False,
+    "properties": {
+        "name": {"type": "string"},
+        "entries": {
+            "type": "array",
+            "items": _entry_schema,
+        }
+    },
+    "required": ["name", "entries"],
+}

--- a/rift/api/schemas/schedule.py
+++ b/rift/api/schemas/schedule.py
@@ -3,8 +3,8 @@ _entry_schema = {
     "properties": {
         "job_id": {"type": "string"},
         "delay": {
-            "type": "integer",
-            "minimum": 0
+            "type": "string",
+            "pattern": "[0-9]{2}:[0-9]{2}:[0-9]{2}",
         },
     },
     "required": ["job_id", "delay"],

--- a/rift/app.py
+++ b/rift/app.py
@@ -19,7 +19,8 @@ from rift import log
 from rift.data import common
 from rift.api.version.resources import VersionResource
 from rift.api.resources import (JobsResource, JobResource, TenantsResource,
-                                TargetsResource, TargetResource)
+                                TargetsResource, TargetResource,
+                                SchedulesResource, ScheduleResource)
 
 LOG = log.get_logger()
 
@@ -39,6 +40,8 @@ class App(falcon.API):
         tenants = TenantsResource()
         targets = TargetsResource()
         get_target = TargetResource()
+        schedules = SchedulesResource()
+        get_schedule = ScheduleResource()
 
         self.add_route('/', version)
         self.add_route('/v1/{tenant_id}', tenants)
@@ -46,5 +49,7 @@ class App(falcon.API):
         self.add_route('/v1/{tenant_id}/jobs/{job_id}', get_job)
         self.add_route('/v1/{tenant_id}/targets', targets)
         self.add_route('/v1/{tenant_id}/targets/{target_id}', get_target)
+        self.add_route('/v1/{tenant_id}/schedules', schedules)
+        self.add_route('/v1/{tenant_id}/schedules/{schedule_id}', get_schedule)
 
 application = App()

--- a/rift/data/models/schedule.py
+++ b/rift/data/models/schedule.py
@@ -1,0 +1,114 @@
+import uuid
+
+from rift.data.handler import get_handler
+
+SCHEDULE_COLLECTION = "schedules"
+
+
+class Schedule(object):
+
+    def __init__(self, tenant_id, schedule_id, entries, name):
+        self.tenant_id = tenant_id
+        self.schedule_id = schedule_id
+        self.entries = entries
+        self.name = name
+
+    def as_dict(self):
+        return {
+            'id': self.schedule_id,
+            'name': self.name,
+            'entries': [e.as_dict() for e in self.entries],
+        }
+
+    @classmethod
+    def build_schedule_from_dict(cls, tenant_id, schedule_dict):
+        if not schedule_dict:
+            return
+        kwargs = {
+            'schedule_id': schedule_dict.get('id', str(uuid.uuid4())),
+            'name': schedule_dict.get('name'),
+            'entries': [
+                Entry.build_entry_from_dict(e)
+                for e in schedule_dict.get('entries')
+            ],
+        }
+        return cls(tenant_id, **kwargs)
+
+    @classmethod
+    def save_schedule(cls, schedule):
+        db_dict = schedule.as_dict()
+        db_dict['tenant_id'] = schedule.tenant_id
+
+        db_handler = get_handler()
+        db_handler.insert_document(
+            object_name=SCHEDULE_COLLECTION, document=db_dict
+        )
+
+    @classmethod
+    def get_schedule(cls, tenant_id, schedule_id):
+        db_handler = get_handler()
+        schedule_dict = db_handler.get_document(
+            object_name=SCHEDULE_COLLECTION,
+            query_filter={"id": schedule_id})
+        return cls.build_schedule_from_dict(tenant_id, schedule_dict)
+
+    @classmethod
+    def get_schedules(cls, tenant_id):
+        db_handler = get_handler()
+        schedules_dict = db_handler.get_documents(
+            object_name=SCHEDULE_COLLECTION,
+            query_filter={"tenant_id": tenant_id})
+        return [cls.build_schedule_from_dict(tenant_id, schedule)
+                for schedule in schedules_dict]
+
+    @classmethod
+    def delete_schedule(cls, schedule_id):
+        db_handler = get_handler()
+        db_handler.delete_document(
+            object_name=SCHEDULE_COLLECTION,
+            query_filter={"id": schedule_id})
+
+
+class Entry(object):
+
+    def __init__(self, job_id, delay):
+        self.job_id = job_id
+        self.delay = delay
+
+    def as_dict(self):
+        return {
+            'job_id': self.job_id,
+            'delay': self.delay.as_dict(),
+        }
+
+    @classmethod
+    def build_entry_from_dict(cls, entry_dict):
+        kwargs = {
+            'job_id': entry_dict.get('job_id'),
+            'delay': Delay.build_delay_from_dict(entry_dict.get('delay')),
+        }
+        return cls(**kwargs)
+
+
+class Delay(object):
+
+    def __init__(self, seconds, minutes, hours):
+        self.seconds = seconds
+        self.minutes = minutes
+        self.hours = hours
+
+    def as_dict(self):
+        return {
+            'seconds': self.seconds,
+            'minutes': self.minutes,
+            'hours': self.hours,
+        }
+
+    @classmethod
+    def build_delay_from_dict(cls, delay_dict):
+        kwargs = {
+            'seconds': delay_dict.get('seconds', 0),
+            'minutes': delay_dict.get('minutes', 0),
+            'hours': delay_dict.get('hours', 0),
+        }
+        return cls(**kwargs)

--- a/rift/data/models/schedule.py
+++ b/rift/data/models/schedule.py
@@ -88,3 +88,7 @@ class Entry(object):
             'delay': entry_dict.get('delay'),
         }
         return cls(**kwargs)
+
+    def get_total_seconds(self):
+        hours, minutes, seconds = map(int, self.delay.split(':'))
+        return hours * 3600 + minutes * 60 + seconds

--- a/rift/data/models/schedule.py
+++ b/rift/data/models/schedule.py
@@ -78,40 +78,13 @@ class Entry(object):
     def as_dict(self):
         return {
             'job_id': self.job_id,
-            'delay': self.delay.as_dict(),
+            'delay': self.delay,
         }
 
     @classmethod
     def build_entry_from_dict(cls, entry_dict):
         kwargs = {
             'job_id': entry_dict.get('job_id'),
-            'delay': Delay.build_delay_from_dict(entry_dict.get('delay')),
-        }
-        return cls(**kwargs)
-
-
-class Delay(object):
-
-    def __init__(self, seconds, minutes, hours):
-        self.seconds = seconds
-        self.minutes = minutes
-        self.hours = hours
-
-    def as_dict(self):
-        return {
-            'seconds': self.seconds,
-            'minutes': self.minutes,
-            'hours': self.hours,
-        }
-
-    def get_total_seconds(self):
-        return self.seconds + 60 * self.minutes + 3600 * self.hours
-
-    @classmethod
-    def build_delay_from_dict(cls, delay_dict):
-        kwargs = {
-            'seconds': delay_dict.get('seconds', 0),
-            'minutes': delay_dict.get('minutes', 0),
-            'hours': delay_dict.get('hours', 0),
+            'delay': entry_dict.get('delay'),
         }
         return cls(**kwargs)

--- a/rift/data/models/schedule.py
+++ b/rift/data/models/schedule.py
@@ -104,6 +104,9 @@ class Delay(object):
             'hours': self.hours,
         }
 
+    def get_total_seconds(self):
+        return self.seconds + 60 * self.minutes + 3600 * self.hours
+
     @classmethod
     def build_delay_from_dict(cls, delay_dict):
         kwargs = {

--- a/spec/rift/api/datasets.py
+++ b/spec/rift/api/datasets.py
@@ -210,3 +210,12 @@ VALID_TARGETS = {
         }
     }
 }
+
+VALID_SCHEDULES = {
+    'schedule_with_empty_entries': {
+        'body': {
+            "name": "a valid schedule with no entries",
+            "entries": [],
+        }
+    }
+}

--- a/spec/rift/api/datasets.py
+++ b/spec/rift/api/datasets.py
@@ -213,9 +213,99 @@ VALID_TARGETS = {
 
 VALID_SCHEDULES = {
     'schedule_with_empty_entries': {
-        'body': {
+        'body': """{
             "name": "a valid schedule with no entries",
-            "entries": [],
-        }
+            "entries": []
+        }"""
+    },
+    'schedule_with_one_entry': {
+        'body': """{
+            "name": "a valid schedule with one entry",
+            "entries": [
+                {
+                    "job_id": "5e48c156-7550-485d-bcdc-227c2c20d120",
+                    "delay": 0
+                }
+            ]
+        }"""
+    },
+    'schedule_with_two_entries': {
+        'body': """{
+            "name": "a valid schedule with two entries",
+            "entries": [
+                {
+                    "job_id": "5e48c156-7550-485d-bcdc-227c2c20d120",
+                    "delay": 0
+                },
+                {
+                    "job_id": "f06f0ec2-bebf-492f-9a5e-1f8f18d5c277",
+                    "delay": 10
+                }
+            ]
+        }"""
+    },
+}
+
+INVALID_SCHEDULES = {
+    'schedule_with_missing_entries': {
+        'body': """{
+            "name": "a schedule missing the 'entries' key"
+        }"""
+    },
+    'schedule_with_missing_name': {
+        'body': """{
+            "entries": []
+        }"""
+    },
+    'schedule_without_delay': {
+        'body': """{
+            "name": "a schedule with a missing delay key",
+            "entries": [
+                {
+                    "job_id": "f06f0ec2-bebf-492f-9a5e-1f8f18d5c277"
+                }
+            ]
+        }"""
+    },
+    'schedule_with_negative_delay': {
+        'body': """{
+            "name": "a schedule with a missing delay key",
+            "entries": [
+                {
+                    "job_id": "f06f0ec2-bebf-492f-9a5e-1f8f18d5c277"
+                }
+            ]
+        }"""
+    },
+    'schedule_with_negative_delay': {
+        'body': """{
+            "name": "a schedule with a missing delay key",
+            "entries": [
+                {
+                    "job_id": "f06f0ec2-bebf-492f-9a5e-1f8f18d5c277",
+                    "delay": -1
+                }
+            ]
+        }"""
+    },
+    'schedule_without_job_id': {
+        'body': """{
+            "name": "a schedule with a missing delay key",
+            "entries": [
+                {
+                    "delay": -1
+                }
+            ]
+        }"""
+    },
+    'schedule_with_wrong_delay_datatype': {
+        'body': """{
+            "name": "a schedule with a missing delay key",
+            "entries": [
+                {
+                    "delay": "aaa"
+                }
+            ]
+        }"""
     }
 }

--- a/spec/rift/api/datasets.py
+++ b/spec/rift/api/datasets.py
@@ -224,7 +224,7 @@ VALID_SCHEDULES = {
             "entries": [
                 {
                     "job_id": "5e48c156-7550-485d-bcdc-227c2c20d120",
-                    "delay": 0
+                    "delay": "00:00:00"
                 }
             ]
         }"""
@@ -235,11 +235,11 @@ VALID_SCHEDULES = {
             "entries": [
                 {
                     "job_id": "5e48c156-7550-485d-bcdc-227c2c20d120",
-                    "delay": 0
+                    "delay": "00:00:00"
                 },
                 {
                     "job_id": "f06f0ec2-bebf-492f-9a5e-1f8f18d5c277",
-                    "delay": 10
+                    "delay": "11:22:33"
                 }
             ]
         }"""
@@ -259,51 +259,64 @@ INVALID_SCHEDULES = {
     },
     'schedule_without_delay': {
         'body': """{
-            "name": "a schedule with a missing delay key",
+            "name": "a schedule without the delay",
             "entries": [
                 {
                     "job_id": "f06f0ec2-bebf-492f-9a5e-1f8f18d5c277"
-                }
-            ]
-        }"""
-    },
-    'schedule_with_negative_delay': {
-        'body': """{
-            "name": "a schedule with a missing delay key",
-            "entries": [
-                {
-                    "job_id": "f06f0ec2-bebf-492f-9a5e-1f8f18d5c277"
-                }
-            ]
-        }"""
-    },
-    'schedule_with_negative_delay': {
-        'body': """{
-            "name": "a schedule with a missing delay key",
-            "entries": [
-                {
-                    "job_id": "f06f0ec2-bebf-492f-9a5e-1f8f18d5c277",
-                    "delay": -1
                 }
             ]
         }"""
     },
     'schedule_without_job_id': {
         'body': """{
-            "name": "a schedule with a missing delay key",
+            "name": "a schedule without the job id",
             "entries": [
                 {
-                    "delay": -1
+                    "delay": "00:00:00"
                 }
             ]
         }"""
     },
     'schedule_with_wrong_delay_datatype': {
         'body': """{
-            "name": "a schedule with a missing delay key",
+            "name": "a schedule",
             "entries": [
                 {
-                    "delay": "aaa"
+                    "job_id": "f06f0ec2-bebf-492f-9a5e-1f8f18d5c277",
+                    "delay": 123
+                }
+            ]
+        }"""
+    },
+    'schedule_with_single_digits_in_the_delay': {
+        'body': """{
+            "name": "a schedule",
+            "entries": [
+                {
+                    "job_id": "f06f0ec2-bebf-492f-9a5e-1f8f18d5c277",
+                    "delay": "0:0:0"
+                }
+            ]
+        }"""
+    },
+    'schedule_with_invalid_characters_in_the_delay': {
+        'body': """{
+            "name": "a schedule",
+            "entries": [
+                {
+                    "job_id": "f06f0ec2-bebf-492f-9a5e-1f8f18d5c277",
+                    "delay": "A:B:C"
+                }
+            ]
+        }"""
+    },
+    'schedule_without_hours_in_the_delay': {
+        'body': """{
+            "name": "a schedule",
+            "entries": [
+                {
+                    "job_id": "f06f0ec2-bebf-492f-9a5e-1f8f18d5c277",
+                    "delay": "00:00"
                 }
             ]
         }"""

--- a/spec/rift/api/resources/schedule.py
+++ b/spec/rift/api/resources/schedule.py
@@ -2,6 +2,7 @@ import json
 import uuid
 
 from specter import DataSpec, expect, require, skip
+import mock
 
 from spec.rift.api.resources.fixtures import MockedDatabase
 from spec.rift.api.datasets import VALID_SCHEDULES, INVALID_SCHEDULES
@@ -11,7 +12,9 @@ class SchedulesResource(MockedDatabase):
 
     def before_each(self):
         super(type(self), self).before_each()
-        post_resp = self._post_schedule()
+        body = VALID_SCHEDULES['schedule_with_one_entry']['body']
+        self.schedule_body = json.loads(body)
+        post_resp = self._post_schedule(self.schedule_body)
         self.schedule_id = post_resp.json['schedule_id']
         self.schedule_path = '/v1/user/schedules/{0}'.format(self.schedule_id)
 
@@ -26,12 +29,11 @@ class SchedulesResource(MockedDatabase):
         require(resp.status_int).to.equal(200)
         expect(resp.json).to.contain('id')
         expect(resp.json).to.contain('name')
-        require(resp.json).to.contain('entries')
-        expect(resp.json['entries']).to.equal([])
 
-    def can_head_schedule(self):
-        resp = self.app.head(self.schedule_path)
-        expect(resp.status_int).to.equal(200)
+        require(resp.json).to.contain('entries')
+        expect(len(resp.json['entries'])).to.equal(1)
+        expect(resp.json['entries'][0]).to.contain('job_id')
+        expect(resp.json['entries'][0]).to.contain('delay')
 
     @skip('Fails - "not enough arguments for format string" in mongomock')
     def can_delete_schedule(self):
@@ -51,9 +53,7 @@ class SchedulesResource(MockedDatabase):
                              expect_errors=True)
         expect(resp.status_int).to.equal(404)
 
-    def _post_schedule(self):
-        body = VALID_SCHEDULES['schedule_with_empty_entries']['body']
-        body = json.loads(body)
+    def _post_schedule(self, body):
         resp = self.app.post_json('/v1/user/schedules', body)
         require(resp.status_int).to.equal(201)
         require(resp.json).to.contain('schedule_id')
@@ -64,7 +64,7 @@ class SchedulesResource(MockedDatabase):
 
         def can_post_self(self, body):
             body = json.loads(body)
-            resp = self.app.post_json('/v1/tenant/schedules', body)
+            resp = self.app.post_json('/v1/user/schedules', body)
             require(resp.status_int).to.equal(201)
             expect(resp.json).to.contain('schedule_id')
 
@@ -73,6 +73,26 @@ class SchedulesResource(MockedDatabase):
 
         def returns_400_on_a(self, body):
             body = json.loads(body)
-            resp = self.app.post_json('/v1/tenant/schedules', body,
+            resp = self.app.post_json('/v1/user/schedules', body,
                                       expect_errors=True)
             expect(resp.status_int).to.equal(400)
+
+    class SuccessfulHeadRequests(MockedDatabase, DataSpec):
+        DATASET = VALID_SCHEDULES
+
+        def can_run_schedule(self, body):
+            schedule_body = json.loads(body)
+
+            # post a schedule
+            post_resp = self.app.post_json('/v1/user/schedules', schedule_body)
+            require(post_resp.status_int).to.equal(201)
+            require(post_resp.json).to.contain('schedule_id')
+            schedule_id = post_resp.json['schedule_id']
+            schedule_path = '/v1/user/schedules/{0}'.format(schedule_id)
+
+            # run the schedule
+            with mock.patch('rift.api.resources.execute_job') as execute_job:
+                resp = self.app.head(schedule_path)
+                expect(resp.status_int).to.equal(200)
+                n_entries = len(schedule_body['entries'])
+                expect(len(execute_job.mock_calls)).to.equal(n_entries)

--- a/spec/rift/api/resources/schedule.py
+++ b/spec/rift/api/resources/schedule.py
@@ -8,43 +8,51 @@ from spec.rift.api.datasets import VALID_SCHEDULES
 
 class SchedulesResource(MockedDatabase):
 
+    def before_each(self):
+        super(type(self), self).before_each()
+        post_resp = self._post_schedule()
+        self.schedule_id = post_resp.json['schedule_id']
+        self.schedule_path = '/v1/user/schedules/{0}'.format(self.schedule_id)
+
     def can_list_schedules(self):
-        resp = self.app.get('/v1/tenant/schedules')
+        resp = self.app.get('/v1/user/schedules')
         require(resp.status_int).to.equal(200)
         require(resp.json).to.contain('schedules')
-        expect(resp.json['schedules']).to.equal([])
+        expect(len(resp.json['schedules'])).to.equal(1)
 
     def can_get_schedule(self):
-        post_resp = self._post_schedule()
-        schedule_id = post_resp.json['schedule_id']
-
-        resp = self.app.get('/v1/tenant/schedules/{0}'.format(schedule_id))
+        resp = self.app.get(self.schedule_path)
         require(resp.status_int).to.equal(200)
         expect(resp.json).to.contain('id')
         expect(resp.json).to.contain('name')
         require(resp.json).to.contain('entries')
         expect(resp.json['entries']).to.equal([])
 
+    def can_head_schedule(self):
+        resp = self.app.head(self.schedule_path)
+        expect(resp.status_int).to.equal(200)
+
     @skip('Fails - "not enough arguments for format string" in mongomock')
     def can_delete_schedule(self):
-        post_resp = self._post_schedule()
-        schedule_id = post_resp.json['schedule_id']
-
-        url = '/v1/tenant/schedules/{0}'.format(schedule_id)
-        resp = self.app.delete(url)
+        resp = self.app.delete(self.schedule_path)
         require(resp.status_int).to.equal(200)
 
-        resp = self.app.get(url, expect_errors=True)
+        resp = self.app.get(self.schedule_path, expect_errors=True)
         expect(resp.status_int).to.equal(404)
 
-    def should_404_on_nonexistent_schedule(self):
-        resp = self.app.get('/v1/tenant/schedules/{0}'.format(uuid.uuid4()),
+    def get_404s_on_missing_schedule(self):
+        resp = self.app.get('/v1/user/schedules/{0}'.format(uuid.uuid4()),
                             expect_errors=True)
+        expect(resp.status_int).to.equal(404)
+
+    def head_404s_on_missing_schedule(self):
+        resp = self.app.head('/v1/user/schedules/{0}'.format(uuid.uuid4()),
+                             expect_errors=True)
         expect(resp.status_int).to.equal(404)
 
     def _post_schedule(self):
         body = VALID_SCHEDULES['schedule_with_empty_entries']['body']
-        resp = self.app.post_json('/v1/tenant/schedules', body)
+        resp = self.app.post_json('/v1/user/schedules', body)
         require(resp.status_int).to.equal(201)
         require(resp.json).to.contain('schedule_id')
         return resp

--- a/spec/rift/api/resources/schedule.py
+++ b/spec/rift/api/resources/schedule.py
@@ -1,0 +1,50 @@
+import uuid
+
+from specter import expect, require, skip
+
+from spec.rift.api.resources.fixtures import MockedDatabase
+from spec.rift.api.datasets import VALID_SCHEDULES
+
+
+class SchedulesResource(MockedDatabase):
+
+    def can_list_schedules(self):
+        resp = self.app.get('/v1/tenant/schedules')
+        require(resp.status_int).to.equal(200)
+        require(resp.json).to.contain('schedules')
+        expect(resp.json['schedules']).to.equal([])
+
+    def can_get_schedule(self):
+        post_resp = self._post_schedule()
+        schedule_id = post_resp.json['schedule_id']
+
+        resp = self.app.get('/v1/tenant/schedules/{0}'.format(schedule_id))
+        require(resp.status_int).to.equal(200)
+        expect(resp.json).to.contain('id')
+        expect(resp.json).to.contain('name')
+        require(resp.json).to.contain('entries')
+        expect(resp.json['entries']).to.equal([])
+
+    @skip('Fails - "not enough arguments for format string" in mongomock')
+    def can_delete_schedule(self):
+        post_resp = self._post_schedule()
+        schedule_id = post_resp.json['schedule_id']
+
+        url = '/v1/tenant/schedules/{0}'.format(schedule_id)
+        resp = self.app.delete(url)
+        require(resp.status_int).to.equal(200)
+
+        resp = self.app.get(url, expect_errors=True)
+        expect(resp.status_int).to.equal(404)
+
+    def should_404_on_nonexistent_schedule(self):
+        resp = self.app.get('/v1/tenant/schedules/{0}'.format(uuid.uuid4()),
+                            expect_errors=True)
+        expect(resp.status_int).to.equal(404)
+
+    def _post_schedule(self):
+        body = VALID_SCHEDULES['schedule_with_empty_entries']['body']
+        resp = self.app.post_json('/v1/tenant/schedules', body)
+        require(resp.status_int).to.equal(201)
+        require(resp.json).to.contain('schedule_id')
+        return resp

--- a/spec/rift/api/schemas/schedule.py
+++ b/spec/rift/api/schemas/schedule.py
@@ -25,5 +25,3 @@ class ScheduleValidator(Spec):
             body = json.loads(body)
             validator = get_validator(schedule_schema)
             validator.validate(body)
-
-

--- a/spec/rift/api/schemas/schedule.py
+++ b/spec/rift/api/schemas/schedule.py
@@ -1,0 +1,29 @@
+import json
+
+from jsonschema.exceptions import ValidationError
+
+from specter import Spec, DataSpec, expect
+from rift.api.schemas import get_validator
+from rift.api.schemas.schedule import schedule_schema
+from spec.rift.api.datasets import INVALID_SCHEDULES, VALID_SCHEDULES
+
+
+class ScheduleValidator(Spec):
+
+    class InvalidSchedule(DataSpec):
+        DATASET = INVALID_SCHEDULES
+
+        def fails_to_falidate(self, body):
+            body = json.loads(body)
+            validator = get_validator(schedule_schema)
+            expect(validator.validate, [body]).to.raise_a(ValidationError)
+
+    class ValidSchedule(DataSpec):
+        DATASET = VALID_SCHEDULES
+
+        def validates(self, body):
+            body = json.loads(body)
+            validator = get_validator(schedule_schema)
+            validator.validate(body)
+
+

--- a/spec/rift/data/models/schedule.py
+++ b/spec/rift/data/models/schedule.py
@@ -12,7 +12,7 @@ example_schedule_dict = {
     'entries': [
         {
             "job_id": "job1",
-            "delay": 123,
+            "delay": "01:02:03",
         }
     ]
 }
@@ -32,12 +32,12 @@ class ScheduleModel(Spec):
             expect(schedule.name).to.equal('my schedule')
 
             expect(schedule.entries[0].job_id).to.equal('job1')
-            expect(schedule.entries[0].delay).to.equal(123)
+            expect(schedule.entries[0].delay).to.equal("01:02:03")
 
     class Serialization(Spec):
 
         def can_serialize_to_a_dictionary(self):
-            entry = Entry(job_id='job1', delay=123)
+            entry = Entry(job_id='job1', delay="01:02:03")
             schedule = Schedule(tenant_id='tenant1',
                                 schedule_id='schedule1',
                                 entries=[entry],
@@ -50,7 +50,7 @@ class ScheduleModel(Spec):
 
             e = schedule_dict['entries'][0]
             expect(e.get('job_id')).to.equal('job1')
-            expect(e.get('delay')).to.equal(123)
+            expect(e.get('delay')).to.equal("01:02:03")
 
     class DatabaseActions(MockedDatabase):
 

--- a/spec/rift/data/models/schedule.py
+++ b/spec/rift/data/models/schedule.py
@@ -2,7 +2,7 @@ import uuid
 
 from specter import Spec, expect, skip
 
-from rift.data.models.schedule import Schedule, Entry, Delay
+from rift.data.models.schedule import Schedule, Entry
 from spec.rift.api.resources.fixtures import MockedDatabase
 
 
@@ -12,11 +12,7 @@ example_schedule_dict = {
     'entries': [
         {
             "job_id": "job1",
-            "delay": {
-                "seconds": 3,
-                "minutes": 2,
-                "hours": 1,
-            }
+            "delay": 123,
         }
     ]
 }
@@ -25,6 +21,7 @@ example_schedule_dict = {
 class ScheduleModel(Spec):
 
     class Deserialization(Spec):
+
         def can_deserialize_from_a_dictionary(self):
             tenant_id = str(uuid.uuid4())
             schedule = Schedule.build_schedule_from_dict(
@@ -35,14 +32,12 @@ class ScheduleModel(Spec):
             expect(schedule.name).to.equal('my schedule')
 
             expect(schedule.entries[0].job_id).to.equal('job1')
-            expect(schedule.entries[0].delay.seconds).to.equal(3)
-            expect(schedule.entries[0].delay.minutes).to.equal(2)
-            expect(schedule.entries[0].delay.hours).to.equal(1)
+            expect(schedule.entries[0].delay).to.equal(123)
 
     class Serialization(Spec):
+
         def can_serialize_to_a_dictionary(self):
-            delay = Delay(seconds=1, minutes=2, hours=3)
-            entry = Entry(job_id='job1', delay=delay)
+            entry = Entry(job_id='job1', delay=123)
             schedule = Schedule(tenant_id='tenant1',
                                 schedule_id='schedule1',
                                 entries=[entry],
@@ -55,13 +50,10 @@ class ScheduleModel(Spec):
 
             e = schedule_dict['entries'][0]
             expect(e.get('job_id')).to.equal('job1')
-            expect(e.get('delay')).to.equal({
-                'seconds': 1,
-                'minutes': 2,
-                'hours': 3,
-            })
+            expect(e.get('delay')).to.equal(123)
 
     class DatabaseActions(MockedDatabase):
+
         def before_each(self):
             super(type(self), self).before_each()
             self.tenant_id = str(uuid.uuid4())
@@ -89,9 +81,3 @@ class ScheduleModel(Spec):
             found = Schedule.get_schedule(
                 self.tenant_id, self.schedule.schedule_id)
             expect(found).to.be_none()
-
-    class DelayModel(Spec):
-
-        def can_get_total_seconds(self):
-            delay = Delay(seconds=3, minutes=2, hours=1)
-            expect(delay.get_total_seconds()).to.equal(3723)

--- a/spec/rift/data/models/schedule.py
+++ b/spec/rift/data/models/schedule.py
@@ -1,6 +1,6 @@
 import uuid
 
-from specter import Spec, expect, skip
+from specter import Spec, DataSpec, expect, skip
 
 from rift.data.models.schedule import Schedule, Entry
 from spec.rift.api.resources.fixtures import MockedDatabase
@@ -81,3 +81,31 @@ class ScheduleModel(Spec):
             found = Schedule.get_schedule(
                 self.tenant_id, self.schedule.schedule_id)
             expect(found).to.be_none()
+
+    class Entry(DataSpec):
+        DATASET = {
+            'zero_delay': {
+                "delay": "00:00:00",
+                "result": 0,
+            },
+            'delay_with_nonzero_seconds': {
+                "delay": "00:00:93",
+                "result": 93,
+            },
+            'delay_with_nonzero_minutes': {
+                "delay": "00:84:00",
+                "result": 5040,
+            },
+            'delay_with_nonzero_hours': {
+                "delay": "67:00:00",
+                "result": 241200,
+            },
+            'delay_with_hours_minutes_and_seconds': {
+                "delay": "12:34:56",
+                "result": 45296,
+            },
+        }
+
+        def can_get_total_seconds_for(self, delay, result):
+            entry = Entry(job_id=str(uuid.uuid4()), delay=delay)
+            expect(entry.get_total_seconds()).to.equal(result)

--- a/spec/rift/data/models/schedule.py
+++ b/spec/rift/data/models/schedule.py
@@ -1,0 +1,97 @@
+import uuid
+
+from specter import Spec, expect, skip
+
+from rift.data.models.schedule import Schedule, Entry, Delay
+from spec.rift.api.resources.fixtures import MockedDatabase
+
+
+example_schedule_dict = {
+    'id': '1234',
+    'name': 'my schedule',
+    'entries': [
+        {
+            "job_id": "job1",
+            "delay": {
+                "seconds": 3,
+                "minutes": 2,
+                "hours": 1,
+            }
+        }
+    ]
+}
+
+
+class ScheduleModel(Spec):
+
+    class Deserialization(Spec):
+        def can_deserialize_from_a_dictionary(self):
+            tenant_id = str(uuid.uuid4())
+            schedule = Schedule.build_schedule_from_dict(
+                tenant_id, example_schedule_dict)
+
+            expect(schedule.tenant_id).to.equal(tenant_id)
+            expect(schedule.schedule_id).to.equal('1234')
+            expect(schedule.name).to.equal('my schedule')
+
+            expect(schedule.entries[0].job_id).to.equal('job1')
+            expect(schedule.entries[0].delay.seconds).to.equal(3)
+            expect(schedule.entries[0].delay.minutes).to.equal(2)
+            expect(schedule.entries[0].delay.hours).to.equal(1)
+
+    class Serialization(Spec):
+        def can_serialize_to_a_dictionary(self):
+            delay = Delay(seconds=1, minutes=2, hours=3)
+            entry = Entry(job_id='job1', delay=delay)
+            schedule = Schedule(tenant_id='tenant1',
+                                schedule_id='schedule1',
+                                entries=[entry],
+                                name='my schedule')
+
+            schedule_dict = schedule.as_dict()
+            expect(schedule_dict.get('id')).to.equal('schedule1')
+            expect(schedule_dict.get('name')).to.equal('my schedule')
+            expect(len(schedule_dict.get('entries', []))).to.equal(1)
+
+            e = schedule_dict['entries'][0]
+            expect(e.get('job_id')).to.equal('job1')
+            expect(e.get('delay')).to.equal({
+                'seconds': 1,
+                'minutes': 2,
+                'hours': 3,
+            })
+
+    class DatabaseActions(MockedDatabase):
+        def before_each(self):
+            super(type(self), self).before_each()
+            self.tenant_id = str(uuid.uuid4())
+            self.schedule = Schedule.build_schedule_from_dict(
+                self.tenant_id, example_schedule_dict)
+            Schedule.save_schedule(self.schedule)
+
+        def can_save_and_get_a_schedule(self):
+            found = Schedule.get_schedule(
+                self.tenant_id, self.schedule.schedule_id)
+            expect(found.as_dict()).to.equal(example_schedule_dict)
+
+        def should_fail_to_get_missing_schedule(self):
+            found = Schedule.get_schedule(self.tenant_id, str(uuid.uuid4()))
+            expect(found).to.be_none()
+
+        def can_get_schedules(self):
+            schedules = Schedule.get_schedules(self.tenant_id)
+            expect(len(schedules)).to.equal(1)
+            expect(schedules[0].as_dict()).to.equal(example_schedule_dict)
+
+        @skip('Fails - "not enough arguments for format string" in mongomock')
+        def can_delete(self):
+            Schedule.delete_schedule(self.schedule.schedule_id)
+            found = Schedule.get_schedule(
+                self.tenant_id, self.schedule.schedule_id)
+            expect(found).to.be_none()
+
+    class DelayModel(Spec):
+
+        def can_get_total_seconds(self):
+            delay = Delay(seconds=3, minutes=2, hours=1)
+            expect(delay.get_total_seconds()).to.equal(3723)


### PR DESCRIPTION
Todos:
- [x] Schema validation
- [x] Testing the calls to `execute_job` when a schedule is run

This lets you post to `/schedules` to kick off a group of jobs that run according to a schedule, which is the most straightforward thing it could be, I think:

	POST /v1/tenant/schedules
	{
	    "name": "a-three-job-schedule",
	    "entries": [
	        {
	            "job_id": "<job-1>",
	            "delay": {
	                "seconds": 5,
	                "minutes": 0,
	                "hours": 0
	            }
	        },
	        {
	            "job_id": "<job-2>",
	            "delay": {
	                "seconds": 10,
	                "minutes": 0,
	                "hours": 0
	            }
	        },
	        {
	            "job_id": "<job-3>",
	            "delay": {
	                "seconds": 15,
	                "minutes": 0,
	                "hours": 0
	            }
	        }
	    ]
	}

This would run the first job 5 seconds after the start, the second job after 10 seconds, and the third after 15 seconds. Then you just `HEAD /v1/tenant/schedules/{id}` to start that job schedule. I tested this out with some jobs that touched files on another server, and verified that the last modified timestamps looked reasonable.

And then I'm always open to renaming things, or doing this totally differently if there are other ideas.